### PR TITLE
Allow uppercase hostname in URL

### DIFF
--- a/lib/tpp/tpp.rb
+++ b/lib/tpp/tpp.rb
@@ -183,7 +183,7 @@ class Vcert::TPPConnection
     unless url.end_with?('/vedsdk/')
       url = url + 'vedsdk/'
     end
-    unless url =~ /^https:\/\/[a-z\d]+[-a-z\d.]+[a-z\d][:\d]*\/vedsdk\/$/
+    unless url =~ /^https:\/\/[A-Za-z\d]+[-A-Za-z\d.]+[A-Za-z\d][:\d]*\/vedsdk\/$/
       raise Vcert::ClientBadDataError, "Invalid URL for TPP"
     end
     url

--- a/lib/tpp/tpp_token.rb
+++ b/lib/tpp/tpp_token.rb
@@ -238,7 +238,7 @@ class Vcert::TokenConnection
       url = "https://#{url}"
     end
     url += '/' unless url.end_with?('/')
-    raise Vcert::ClientBadDataError, 'Invalid URL for TPP' unless url =~ %r{^https://[a-z\d]+[-a-z\d.]+[a-z\d][:\d]*/$}
+    raise Vcert::ClientBadDataError, 'Invalid URL for TPP' unless url =~ %r{^https://[A-Za-z\d]+[-A-Za-z\d.]+[A-Za-z\d][:\d]*/$}
 
     url
   end


### PR DESCRIPTION
Allow uppercase hostname in URL since since Net::HTTP is case-sensitive for the TLS handshake (e.g. if certificate has CN=HOSTNAME.COMPANY.COM the URL must be https://HOSTNAME.COMPANY.COM, https://hostname.company.com will fail to connect).